### PR TITLE
remove !important from custom-search-banner h1 as it's not needed

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -4,7 +4,7 @@
   max-width: unset;
   color: var(--secondary);
   h1 {
-    font-size: 4em !important;
+    font-size: 4em;
   }
   p {
     font-size: 1.25em !important;


### PR DESCRIPTION
Please consider removing the !important as this is not needed and makes targeting this in a override difficult.