### PR TITLE
UX: mobile width fix

### DIFF
--- a/mobile/mobile.scss
+++ b/mobile/mobile.scss
@@ -38,7 +38,7 @@ html body.staff:not(.navigation-topics) #main-outlet {
 }
 
 .container.posts > .row {
-  max-width: 100%;
+  max-width: calc(100vw - 1.5em);
 }
 
 .navigation-categories .navigation-container,


### PR DESCRIPTION
Needed to adjust `max-width` on `.container.posts > .row` to use the viewport instead of `%`. Problems were arising when large images or code was posted to a topic.

### After
<img width="400" alt="image" src="https://user-images.githubusercontent.com/30537603/147488433-e7e45d26-ff52-4193-8fda-466fff9e3593.png">

### Before
<img width="399" alt="image" src="https://user-images.githubusercontent.com/30537603/147488450-a7d8836b-d487-477d-bcc2-62592978ec79.png">
