### PR TITLE
UX: Add styling for chat

### DIFF
--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -1,1 +1,2 @@
 @import "showcased-categories";
+@import "chat-desktop";

--- a/mobile/mobile.scss
+++ b/mobile/mobile.scss
@@ -1,3 +1,5 @@
+@import "chat-mobile";
+
 .custom-search-banner-wrap {
   h1 {
     font-size: 2.5em !important;

--- a/scss/chat-desktop.scss
+++ b/scss/chat-desktop.scss
@@ -1,0 +1,21 @@
+.has-full-page-chat #main-outlet.wrap {
+  overflow: hidden;
+  margin-bottom: 30px;
+  padding-bottom: 0px !important;
+  .full-page-chat {
+    grid-template-rows: calc(var(--full-page-chat-height) - 30px);
+  }
+}
+
+@media screen and (max-width: 1366px) {
+  .has-full-page-chat:not(.discourse-sidebar) #main-outlet.wrap {
+    max-width: 100% !important;
+    width: 100% !important;
+    border-radius: 0;
+    margin: 0;
+    padding: 0;
+    .full-page-chat {
+      grid-template-rows: var(--full-page-chat-height);
+    }
+  }
+}

--- a/scss/chat-mobile.scss
+++ b/scss/chat-mobile.scss
@@ -1,0 +1,16 @@
+html
+  body.has-full-page-chat
+  #main-outlet.wrap {
+  width: 100% !important;
+  padding: 0 !important;
+  background-color: var(--secondary) !important;
+}
+
+html body.chat-enabled #main-outlet {
+  width: 100% !important;
+  padding: 0 !important;
+  background-color: var(--secondary) !important;
+  .chat-channels {
+    height: var(--full-page-chat-height);
+  }
+}


### PR DESCRIPTION
This PR adds styling to accommodate for chat on desktop and mobile.

### After
**Desktop**
<img src="https://user-images.githubusercontent.com/30537603/152242301-9ffa826f-4128-4c90-bfe2-bfdb05f41e0b.png" width=700 />

**Mobile**
<img src="https://user-images.githubusercontent.com/30537603/152242383-62165e5d-d783-41e9-9600-230946fb1dda.png" width=300 />

### Before
**Desktop**
<img src="https://user-images.githubusercontent.com/30537603/152242683-2a5742f3-cfcc-44cb-8789-3a22b058236b.png" width=700 />

**Mobile**
<img src="https://user-images.githubusercontent.com/30537603/152242595-74836bef-1188-4a6e-a7b5-ea4123108eed.png" width=300 />