### PR TITLE
Fix to show latest poster's avatar in topic list

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -367,7 +367,7 @@ html body #main-outlet {
         display: flex;
         justify-content: center;
         align-items: center;
-        a:not(:first-of-type) {
+        a:not(.latest) {
           display: none;
         }
       }
@@ -393,7 +393,7 @@ html body #main-outlet {
   display: none;
 }
 
-.full-width .contents .topic-list .topic-list-item .posters a:first-of-type {
+.full-width .contents .topic-list .topic-list-item .posters a.latest {
   margin-right: 4px;
   width: 100%;
   height: 100%;
@@ -437,12 +437,12 @@ html body #main-outlet {
         height: 40px;
         border-radius: 8px;
       }
-      a:first-of-type {
+      a.latest {
         .avatar {
           margin-right: 0;
         }
       }
-      a:not(:first-of-type) {
+      a:not(.latest) {
         margin-left: -22px;
         .avatar {
           border: 3px solid var(--secondary);


### PR DESCRIPTION
In desktop mode, the topic list currently shows the original poster's avatar next to each topic. It should display the latest poster, not the original poster. Since the theme shows only a single avatar and not whole the avatar list, it's most useful to see the latest poster. Also, this change will make desktop view match mobile, which already displays the latest avatar.

@jordanvidrine - I think you're the maintainer of this theme. Can you please review? Thanks!