### PR TITLE
UI: Change the color of the banner text to primary

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -2,7 +2,7 @@
 .custom-search-banner-wrap {
   margin: 0 auto !important;
   max-width: unset;
-  color: var(--secondary);
+  color: var(--primary);
   h1 {
     font-size: 4em;
   }


### PR DESCRIPTION
**PR Summary**:
The PR changes the color of the banner text from `var(--secondary)` to `var(--primary)`. 

I'm not sure why or when it was altered, but it looks like in the latest version of Discourse, the `#main-outlet div` now includes both the banner header and the categories, causing an issue. As both the [background color of `#main-outlet div`](https://github.com/discourse/discourse-air/blob/9c61a6b8398bce4807a5925825756f7664c33ea4/common/common.scss#L254) and the [text color of the banner text](https://github.com/discourse/discourse-air/blob/9c61a6b8398bce4807a5925825756f7664c33ea4/common/common.scss#L5) are set to `var(--secondary)`, the banner text becomes invisible. Currently, it's not possible to use this theme out of a box anymore. A quick solution is to distinguish between the two elements. A more robust solution may be required in the long run.

The current view of the theme:

![image](https://github.com/discourse/discourse-air/assets/35470921/80bc04fc-c740-4f1b-8a71-54bf53667cec)

After the change:

![image](https://github.com/discourse/discourse-air/assets/35470921/4d7c4213-10ca-4a78-bbb5-a1a7bec45ebe)
