### PR TITLE
UX: search banner and chat styles, remove slider

### DIFF
--- a/about.json
+++ b/about.json
@@ -4,7 +4,6 @@
   "license_url": null,
   "components": [
     "https://github.com/jordanvidrine/discourse-category-group-boxes.git",
-    "https://github.com/discourse/discourse-loading-slider.git",
     "https://github.com/discourse/discourse-clickable-topic.git",
     "https://github.com/discourse/discourse-search-banner.git"
   ],

--- a/common/common.scss
+++ b/common/common.scss
@@ -55,6 +55,24 @@
   }
 }
 
+// Ideally the search banner component should be set to use the below-site-header outlet,
+// but this ensures the default works too
+.above-main-container-outlet.search-banner {
+  .custom-search-banner-wrap {
+    padding: 1em 0 2em;
+    color: var(--tertiary);
+    .mobile-view & {
+      color: var(--secondary);
+    }
+    h1 {
+      margin-bottom: 0;
+    }
+    .search-widget {
+      margin-top: 2em;
+    }
+  }
+}
+
 // Main customizations
 .alert {
   margin: 1em 0;

--- a/scss/chat-desktop.scss
+++ b/scss/chat-desktop.scss
@@ -11,6 +11,18 @@ html body.has-sidebar-page.has-full-page-chat {
   border: none !important;
 }
 
+.chat-channel {
+  height: calc(100vh - (var(--header-offset) + 6em));
+}
+
+.chat-composer__wrapper {
+  background: transparent;
+}
+
+.full-page-chat .chat-full-page-header {
+  border-radius: 1em 1em 0 0;
+}
+
 .has-full-page-chat #main-outlet.wrap {
   margin-bottom: 30px;
   padding-bottom: 0px !important;


### PR DESCRIPTION
This adds a default style to the search banner in its default outlet (to avoid it looking broken if someone didn't read the Meta topic), adds some chat styles, and removes the loading slider component (part of core now).

Before:
![Screenshot 2023-08-17 at 3 13 10 PM](https://github.com/discourse/discourse-air/assets/1681963/da62e58a-0f69-465d-9b97-05df7140e8b5)

After: 
![Screenshot 2023-08-17 at 3 04 05 PM](https://github.com/discourse/discourse-air/assets/1681963/cafbd8ad-393d-4629-9b80-6e553f4065d9)

Before:
![Screenshot 2023-08-17 at 3 13 17 PM](https://github.com/discourse/discourse-air/assets/1681963/381dfe26-ca98-4227-8e55-d42a3bceb366)


After:
![Screenshot 2023-08-17 at 3 10 10 PM](https://github.com/discourse/discourse-air/assets/1681963/da31c9de-0efb-4faf-b913-08e96adf75f9)
