### PR TITLE
Remove bottom border radius from not-user-nav nav pills

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -296,7 +296,10 @@ html body #main-outlet {
 
 .nav-pills:not(.user-nav) > li a.active,
 .nav-pills:not(.user-nav) > li > a {
-  border-radius: 0.5em;
+  border-top-left-radius: 0.5em;
+  border-top-right-radius: 0.5em;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
 }
 
 // Topic List


### PR DESCRIPTION
This is a minor change to fix an issue I'm seeing with the `.nav-pills` `a` tags on the preferences page. In short, the border radius causes the highlighted tab to look like a smiling cheshire cat:
![image](https://github.com/discourse/discourse-air/assets/9088720/234bdfe5-197a-48f1-bf80-fe25a2f37cd0)

With the fix (ignore the highlight):
![image](https://github.com/discourse/discourse-air/assets/9088720/1e5a4eeb-db61-4e93-8624-2b89db9aae51)
