### PR TITLE
UX: default mobile /categories styles

### DIFF
--- a/mobile/mobile.scss
+++ b/mobile/mobile.scss
@@ -182,3 +182,21 @@ ol.category-breadcrumb {
 .topic-list .topic-list-item .topic-list-data {
   padding: 15px;
 }
+
+// default category list styles when the modern category boxes theme component isn't used
+
+.category-list-item.category {
+  background: var(--secondary);
+  border-radius: 1em;
+  tbody {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+  }
+  td {
+    width: 100%;
+  }
+  .num.posts {
+    padding-right: 0.25em;
+  }
+}


### PR DESCRIPTION
this theme uses a theme component included by default to style these, but when that component is disabled /categories looks broken on mobile

this PR introduces some default styles (these are still overridden by the theme component when it's installed, so it won't affect that) 

Before:
![Screenshot 2024-01-29 at 10 43 30 AM](https://github.com/discourse/discourse-air/assets/1681963/6b430957-89fd-4bcc-a623-07cfa1fc856f)


After:
![Screenshot 2024-01-29 at 10 43 23 AM](https://github.com/discourse/discourse-air/assets/1681963/cdf6144b-06dc-4ee7-af6e-3ac37c8738f2)
