### PR TITLE
DEV: Always run backwards-compat logic

### DIFF
--- a/javascripts/discourse/initializers/init-topic-excerpts.js
+++ b/javascripts/discourse/initializers/init-topic-excerpts.js
@@ -2,17 +2,12 @@ import { apiInitializer } from "discourse/lib/api";
 import { withSilencedDeprecations } from "discourse-common/lib/deprecated";
 
 export default apiInitializer("0.8", (api) => {
-  const transformerExists = api.registerValueTransformer(
-    "topic-list-item-expand-pinned",
-    () => true
-  );
+  api.registerValueTransformer("topic-list-item-expand-pinned", () => true);
 
-  if (!transformerExists) {
-    withSilencedDeprecations("discourse.hbr-topic-list-overrides", () => {
-      api.modifyClass("component:topic-list-item", {
-        pluginId: "discourse-air",
-        expandPinned: true,
-      });
+  withSilencedDeprecations("discourse.hbr-topic-list-overrides", () => {
+    api.modifyClass("component:topic-list-item", {
+      pluginId: "discourse-air",
+      expandPinned: true,
     });
-  }
+  });
 });


### PR DESCRIPTION
There was a ~1 week period where the modifier existed in core, but only applied to the new topic list.

Running the modifyClass unconditionally takes care of that. We'll be removing it once the raw-hbs topic list is removed in the next few months.