### PR TITLE
UX: fix background issue, chat height

### DIFF
--- a/mobile/mobile.scss
+++ b/mobile/mobile.scss
@@ -15,10 +15,9 @@
 html
   body:not(
     .static-tos,
-    .static-faq,
+    .static-guidelines,
     .static-privacy,
     .about-page,
-    .static-faq,
     .badges-page,
     .tags-page,
     .archetype-banner,
@@ -54,7 +53,7 @@ html body.static-tos #main-outlet,
 html body.no-ember #main-outlet,
 html body.static-privacy #main-outlet,
 html body.about-page #main-outlet,
-html body.static-faq #main-outlet,
+html body.static-guidelines #main-outlet,
 html body.tags-page #main-outlet,
 html body.badges-page #main-outlet,
 html body.archetype-banner #main-outlet,
@@ -68,7 +67,7 @@ html body.user-preferences-page #main-outlet,
 html body.user-messages-page #main-outlet,
 html body.user-notifications-page #main-outlet,
 html body.user-badges-page #main-outlet,
-html body.staff:not(.navigation-topics) #main-outlet {
+html body #main-outlet:has(.container.group) {
   border-radius: 0;
   width: calc(100% - 3em);
   background-color: var(--secondary);

--- a/scss/chat-desktop.scss
+++ b/scss/chat-desktop.scss
@@ -1,6 +1,6 @@
 html body.has-sidebar-page.has-full-page-chat {
   #main-outlet-wrapper {
-    gap: 2em;
+    gap: 0 2em;
   }
 
   #main-outlet {


### PR DESCRIPTION
Fixes a couple minor issues... some backgrounds were missing on mobile and on the guidelines page, and chat layout was a little off 


Before/After:
<img width="400"  alt="image" src="https://github.com/user-attachments/assets/989d553e-3a74-41be-ac2b-ecdf5ccd3b6d" />

<img width="400"  alt="image" src="https://github.com/user-attachments/assets/45cd2ab0-2cb5-4d90-84fe-60499999c564" />


Before/After: 
<img width="400"  alt="image" src="https://github.com/user-attachments/assets/97e6a259-55e2-4794-9da9-79d8c43aa9e3" />
<img width="400"  alt="image" src="https://github.com/user-attachments/assets/74b1958e-6e08-4a7c-a577-3dbfcd8f0674" />


Before/After:
<img width="1000"  alt="image" src="https://github.com/user-attachments/assets/8a4f817d-e494-4753-834a-2ff3d11d0ce1" />
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/efbf0959-a455-482e-93fb-41b0d0db0e5a" />
